### PR TITLE
Wrapped column in Flexible to fix width issue

### DIFF
--- a/lib/src/features/exercise/presentation/exercise.dart
+++ b/lib/src/features/exercise/presentation/exercise.dart
@@ -32,7 +32,8 @@ class _ExcerciseWidgetState extends State<ExcerciseWidget> {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Column(
+              Flexible(
+                  child: Column(
                 children: [
                   Padding(
                     padding: const EdgeInsets.all(16.0),
@@ -52,7 +53,7 @@ class _ExcerciseWidgetState extends State<ExcerciseWidget> {
                     ]),
                   ),
                 ],
-              ),
+              )),
             ],
           ),
         ));


### PR DESCRIPTION
Closes #5 
I placed the upper most column widget in a Flexible widget so it is resized.